### PR TITLE
Using full path when making calls to do_join

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Full outer join of very large files using low resources.
   - md5sum
   - R with the follwoing packages
     - doParallel
-    - R.utils
     - dplyr
     - readr
 
@@ -67,14 +66,14 @@ _NOTE: The working directory should be empty._
 
 ## Quality Control
 
-The full dataset is too big to be produced in R. However, small subsets of the data
-can be managed. Therefore, we can use random selection to verify results. This
-is somewhat imperfect, since we rely on the output file as the stock of keys
-from which we sample.
+The full dataset is too big to be produced in R. However, small subsets of the
+data can be managed. Therefore, we can use random selection to verify results.
+This is somewhat imperfect, since we rely on the output file as the stock of
+keys from which we sample.
 
 A random sample of lines from the outfile (1000 by default) can be read in and
 then a dataset matching those lines can be reproduced by reading in the source
-data. Use *prod_check.r* in the *test/* folder to do this QC check.
+data. Use *prod_check.r* in the *qc/* folder to do this QC check.
 
 ## Test Data
 

--- a/full_join.sh
+++ b/full_join.sh
@@ -6,7 +6,7 @@ progpath="$( dirname "$( readlink -f "$0" )" )"
 set -e
 
 # Standardize sort order
-export LC_ALL=C
+export LC_ALL="en_US.UTF-8"
 
 # Usage -----------------------------------------------------------------------
 function usage {

--- a/full_join.sh
+++ b/full_join.sh
@@ -121,10 +121,9 @@ echo "$progname: Appending columns..." >&2
 # Append columns one-by-one using python3 script
 i=1
 for f in "${work_dir}/sorted_"*; do
-  file_name=$(basename "$f")
-  echo -n "$progname: $(printf '% 5i' $i)/$#: $file_name" >&2
-  test -f "$progpath/bin/do_join" && \
-    "$progpath/bin/do_join" "$f" || \
+  echo -n "$progname: $(printf '% 5i' $i)/$#: $(basename "$f")" >&2
+  test -f   "$progpath/bin/do_join" && \
+            "$progpath/bin/do_join" "$f" || \
     python3 "$progpath/python/do_join.py" "$f"
   rm "$f"
   echo " ($((SECONDS - CHECKPOINT)) seconds)" >&2

--- a/full_join.sh
+++ b/full_join.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-progname=$(basename "$0")
+progname="$( basename "$0" )"
+progpath="$( dirname "$( readlink -f "$0" )" )"
 
 set -e
 
@@ -122,7 +123,9 @@ i=1
 for f in "${work_dir}/sorted_"*; do
   file_name=$(basename "$f")
   echo -n "$progname: $(printf '% 5i' $i)/$#: $file_name" >&2
-  test -f "bin/do_join" && bin/do_join "$f" || python3 python/do_join.py "$f"
+  test -f "$progpath/bin/do_join" && \
+    "$progpath/bin/do_join" "$f" || \
+    python3 "$progpath/python/do_join.py" "$f"
   rm "$f"
   echo " ($((SECONDS - CHECKPOINT)) seconds)" >&2
   CHECKPOINT=$SECONDS

--- a/resume_join.sh
+++ b/resume_join.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 echo "resuming..." >&2
-progname=$(basename $0)
+
+progname="$( basename "$0" )"
+progpath="$( dirname "$( readlink -f "$0" )" )"
+
 CHECKPOINT=$SECONDS
 
 set -e
@@ -60,9 +63,10 @@ echo "$progname: Resuming appending columns..." >&2
 
 i=1
 for f in "${work_dir}/sorted_"*; do
-  file_name=$(basename "$f")
-  echo -n "$progname: $(printf '% 5i' $i)/unknown: $file_name" >&2
-  test -f "bin/do_join" && bin/do_join "$f" || python3 python/do_join.py "$f"
+  echo -n "$progname: $(printf '% 5i' $i)/unknown: $(basename "$f")" >&2
+  test -f   "$progpath/bin/do_join" && \
+            "$progpath/bin/do_join" "$f" || \
+    python3 "$progpath/python/do_join.py" "$f"
   rm "$f"
   echo " ($((SECONDS - CHECKPOINT)) seconds)" >&2
   CHECKPOINT=$SECONDS

--- a/src/do_join.c
+++ b/src/do_join.c
@@ -18,7 +18,8 @@ int compare_keys(char* s1, char* s2)
       continue;
     }
     // No match
-    if ( s1[c] != s2[c] ) return 0;
+    if ( s1[c] != s2[c] )
+      return 0;
     c++;
   }
   return 1;
@@ -69,7 +70,8 @@ int main(int argc, char* argv[])
         continue;
       }
     }
-    if ( in_tag ) putc(argv[1][i], ftmp);
+    if ( in_tag )
+      putc(argv[1][i], ftmp);
   }
 
   // File line buffers

--- a/src/do_join.c
+++ b/src/do_join.c
@@ -3,9 +3,6 @@
 #include <string.h>
 #include <libgen.h>
 
-// fgets result unused for candidate file
-#pragma GCC diagnostic ignored "-Wunused-result"
-
 // Assume keys and first three fields are
 // under 99 characters long (incl. \n)
 #define BASE_LEN 100
@@ -79,7 +76,8 @@ int main(int argc, char* argv[])
   char line[BASE_LEN + 2 * nf], candidate[BASE_LEN];
 
   // Preload the candidate
-  fgets(candidate, BASE_LEN, fin);
+  int rc;
+  rc = fgets(candidate, BASE_LEN, fin) != NULL;
 
   // Iterate over lines
   while ( fgets(line, BASE_LEN + 2 * nf, fout) != NULL )
@@ -89,10 +87,10 @@ int main(int argc, char* argv[])
     fputs(line, ftmp);
     putc(',', ftmp);
 
-    if ( compare_keys(line, candidate) )
+    if ( rc && compare_keys(line, candidate) )
     {
       putc(candidate[strlen(candidate) - 2], ftmp);
-      fgets(candidate, BASE_LEN, fin);
+      rc = fgets(candidate, BASE_LEN, fin) != NULL;
     }
 
     putc('\n', ftmp);

--- a/src/do_join.c
+++ b/src/do_join.c
@@ -27,10 +27,12 @@ int compare_keys(char* s1, char* s2)
 
 int main(int argc, char* argv[])
 {
-  // Get directory name
-  char *dirc, *dname;
+  // Get file name and directory path
+  char *dirc, *dname, *basec, *bname;
   dirc  = strdup(argv[1]);
   dname = dirname(dirc);
+  basec  = strdup(argv[1]);
+  bname = basename(basec);
 
   // Construct working file paths
   char out_path[strlen(dname) + 9],
@@ -60,9 +62,9 @@ int main(int argc, char* argv[])
   putc(',', ftmp);
 
   // Add Accession Tag
-  for ( int i=0, in_tag=0; i < strlen(argv[1]); i++ )
+  for ( int i=0, in_tag=0; bname[i]; i++ )
   {
-    if ( argv[1][i] == '_' ) {
+    if ( bname[i] == '_' ) {
       if ( in_tag++ ) {
         putc('\n', ftmp);
         break;
@@ -71,7 +73,7 @@ int main(int argc, char* argv[])
       }
     }
     if ( in_tag )
-      putc(argv[1][i], ftmp);
+      putc(bname[i], ftmp);
   }
 
   // File line buffers

--- a/test/out/out.md5
+++ b/test/out/out.md5
@@ -1,0 +1,1 @@
+cd661cec3d597a18f684853956c8acd8  test/out/out.csv


### PR DESCRIPTION
This uses the full path of the calling script when making calls to `do_join`. So if you add the MethylMallet repo to your path, you can call the script from anywhere without it breaking. Previously, you needed to call the script from the MethylMallet root directory.