### PR TITLE
popping element from hashmap just sets its value to null string

### DIFF
--- a/full_join.sh
+++ b/full_join.sh
@@ -3,7 +3,7 @@
 progname="$( basename "$0" )"
 progpath="$( dirname "$( readlink -f "$0" )" )"
 
-set -e
+set -e -o pipefail
 
 # Quick check to see if binaries are made
 if [[ ! -x "$progpath/bin/append_tag" || ! -x "$progpath/bin/spread" ]]; then

--- a/makefile
+++ b/makefile
@@ -8,14 +8,5 @@ all: ./bin/append_tag ./bin/spread
 ./bin/append_tag: ./src/append_tag.c
 	$(CXX) $(CXXFLAGS) $< -o $@
 
-./bin/hashmap.o: ./src/hashmap.c
-	$(CXX) $(CXXFLAGS) $^ -o $@ -c
-
-./bin/primes.o: ./src/primes.c
-	$(CXX) $(CXXFLAGS) $^ -o $@ -c
-
-./bin/spread.o: ./src/spread.c
-	$(CXX) $(CXXFLAGS) $^ -o $@ -c
-
-./bin/spread: ./bin/spread.o ./bin/hashmap.o ./bin/primes.o
+./bin/spread: ./src/spread.c ./src/hashmap.c ./src/primes.c
 	$(CXX) $(CXXFLAGS) $^ -o $@

--- a/makefile
+++ b/makefile
@@ -1,11 +1,21 @@
 CXX = gcc
+CXXFLAGS = -O2
 
 .PHONY: all
 
 all: ./bin/append_tag ./bin/spread
 
 ./bin/append_tag: ./src/append_tag.c
-	$(CXX) ./src/append_tag.c -o $@
+	$(CXX) $(CXXFLAGS) $< -o $@
 
-./bin/spread: ./src/spread.c ./src/hashmap.c ./src/hashmap.h ./src/primes.c ./src/primes.h
-	$(CXX) ./src/spread.c ./src/hashmap.c ./src/primes.c -o $@
+./bin/hashmap.o: ./src/hashmap.c
+	$(CXX) $(CXXFLAGS) $^ -o $@ -c
+
+./bin/primes.o: ./src/primes.c
+	$(CXX) $(CXXFLAGS) $^ -o $@ -c
+
+./bin/spread.o: ./src/spread.c
+	$(CXX) $(CXXFLAGS) $^ -o $@ -c
+
+./bin/spread: ./bin/spread.o ./bin/hashmap.o ./bin/primes.o
+	$(CXX) $(CXXFLAGS) $^ -o $@

--- a/src/append_tag.c
+++ b/src/append_tag.c
@@ -1,18 +1,17 @@
 #include <stdio.h>
 #include <string.h>
+#include "config.h"
 
-#define MAX_LINE 1000
-#define MAX_TAG  1000
 #define FIELD_SEP '\t'
 
 void process_line(char *l, char *t)
 {
-  for (int field=1; field <= 4; l++) {
+  for (int field=0; field < KEY_FIELDS; l++) {
     if (*l == FIELD_SEP)
       field++;
     putchar(*l);
   }
-  
+
   fputs(t, stdout);
 
   for (l = strrchr(l, FIELD_SEP); *l != '\0'; l++)
@@ -21,7 +20,7 @@ void process_line(char *l, char *t)
 
 int main(int argc, char *argv[])
 {
-  char line[MAX_LINE], tag[MAX_TAG];
+  char line[MAX_LINE], tag[MAX_FIELD];
   int i;
 
   // Get the tag

--- a/src/config.h
+++ b/src/config.h
@@ -1,0 +1,9 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+#define MAX_LINE  1000
+#define MAX_FIELD  100
+#define KEY_FIELDS   4
+#define N_FIELDS     6
+
+#endif

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -1,15 +1,27 @@
 #include "hashmap.h"
 
-#define BUCKETS 1999
-
-static Node *h[BUCKETS];
+static Node **h;
+static unsigned int buckets;
 
 static unsigned int hash(char *key)
 {
   unsigned int hashval=0L;
   while (*key != '\0')
     hashval = hashval * 31 + *key++;
-  return (unsigned int) hashval % BUCKETS;
+  return (unsigned int) hashval % buckets;
+}
+
+int h_init(unsigned int size)
+{
+  size = size * 1.33f;
+  if (size < 17)
+    buckets = 17;
+  else
+    buckets = is_prime(size) ? size : next_prime(size);
+
+  h = malloc(buckets * sizeof(Node *));
+
+  return h == NULL ? 0 : 1;
 }
 
 Node *h_get(char *key)

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -1,7 +1,5 @@
 #include "hashmap.h"
 
-#define MAX_LEN 100
-
 static Node **h;
 static unsigned int buckets;
 
@@ -40,10 +38,10 @@ int h_pop(char *key, char *dest)
 
   if (p != NULL) {
     strcpy(dest, p->val);
-    memset(p->val, '\0', sizeof(p->val));
+    p->val[0] = '\0';
     return 1;
   } else {
-    memset(dest, '\0', sizeof(dest));
+    dest[0] = '\0';
     return 0;
   }
 }
@@ -55,8 +53,8 @@ void h_ins(char *key, char *val)
 
   if (p == NULL) {
     p = (Node *) malloc(sizeof(*p));
-    p->key = (char *) malloc(sizeof(char) * MAX_LEN);
-    p->val = (char *) malloc(sizeof(char) * MAX_LEN);
+    p->key = (char *) malloc(sizeof(char) * MAX_FIELD);
+    p->val = (char *) malloc(sizeof(char) * MAX_FIELD);
     strcpy(p->key, key);
     strcpy(p->val, val);
     hashval = hash(key);
@@ -66,5 +64,3 @@ void h_ins(char *key, char *val)
     strcpy(p->val, val);
   }
 }
-
-#undef MAX_LEN

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -1,6 +1,7 @@
 #include "hashmap.h"
 
 #define BUCKETS 1999
+#define MAX_LEN  100
 
 static Node *h[BUCKETS];
 
@@ -22,30 +23,16 @@ Node *h_get(char *key)
 
 int h_pop(char *key, char *dest)
 {
-  unsigned int hashval = hash(key);
-  Node *prev = NULL;
+  Node *p = h_get(key);
 
-  for (Node *curr = h[hashval]; curr != NULL; curr = curr->next) {
-    if (strcmp(curr->key, key) == 0) {
-      // Resetting linked list
-      if (prev == NULL)
-        h[hashval] = curr->next;
-      else
-        prev->next = curr->next;
-
-      // Copying data, free memory, and return
-      strcpy(dest, curr->val);
-      free(curr->key);
-      free(curr->val);
-      free(curr);
-      return 1;
-    }
-    prev = curr;
+  if (p != NULL) {
+    strcpy(dest, p->val);
+    memset(p->val, '\0', sizeof(p->val));
+    return 1;
+  } else {
+    memset(dest, '\0', sizeof(dest));
+    return 0;
   }
-
-  // Key not found. Copying null string.
-  dest[0] = '\0';
-  return 0;
 }
 
 void h_ins(char *key, char *val)
@@ -55,13 +42,17 @@ void h_ins(char *key, char *val)
 
   if (p == NULL) {
     p = (Node *) malloc(sizeof(*p));
+    p->key = (char *) malloc(sizeof(char) * MAX_LEN);
+    p->val = (char *) malloc(sizeof(char) * MAX_LEN);
+    strcpy(p->key, key);
+    strcpy(p->val, val);
     hashval = hash(key);
-    p->key = strdup(key);
-    p->val = strdup(val);
     p->next = h[hashval];
     h[hashval] = p;
   } else {
-    free(p->val);
-    p->val = strdup(val);
+    strcpy(p->val, val);
   }
 }
+
+#undef BUCKETS
+#undef MAX_LEN

--- a/src/hashmap.h
+++ b/src/hashmap.h
@@ -11,6 +11,7 @@ typedef struct node {
   struct node *next;
 } Node;
 
+int h_init(int size);
 Node *h_get(char *key);
 void h_ins(char *key, char *val);
 int h_pop(char *key, char *dest);

--- a/src/hashmap.h
+++ b/src/hashmap.h
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <stdio.h>
 #include "primes.h"
+#include "config.h"
 
 typedef struct node {
   char *key;

--- a/src/primes.c
+++ b/src/primes.c
@@ -4,11 +4,9 @@ int is_prime(uint32 n) {
   if (n <= 3)
     return n > 1;
 
-  /* Bitwise & should be faster than modulo arithmetic */
   if ((n & 1) == 0 || n % 3 == 0)
     return 0;
 
-  /* Exploit the 6k +/- 1 rule (3x faster than testing all m per Wikipedia)  */
   for (uint32 i = 5; i*i <= n; i += 6)
     if (n % i == 0 || n % (i + 2) == 0)
       return 0;

--- a/src/primes.c
+++ b/src/primes.c
@@ -4,9 +4,11 @@ int is_prime(uint32 n) {
   if (n <= 3)
     return n > 1;
 
+  /* Bitwise & should be faster than modulo arithmetic */
   if ((n & 1) == 0 || n % 3 == 0)
     return 0;
 
+  /* Exploit the 6k +/- 1 rule (3x faster than testing all m per Wikipedia)  */
   for (uint32 i = 5; i*i <= n; i += 6)
     if (n % i == 0 || n % (i + 2) == 0)
       return 0;

--- a/src/primes.c
+++ b/src/primes.c
@@ -1,0 +1,21 @@
+#include "primes.h"
+
+int is_prime(uint32 n) {
+  if (n <= 3)
+    return n > 1;
+
+  if ((n & 1) == 0 || n % 3 == 0)
+    return 0;
+
+  for (uint32 i = 5; i*i <= n; i += 6)
+    if (n % i == 0 || n % (i + 2) == 0)
+      return 0;
+
+  return 1;
+}
+
+uint32 next_prime(uint32 n) {
+  while (!is_prime(++n))
+    ;
+  return n;
+}

--- a/src/primes.h
+++ b/src/primes.h
@@ -1,0 +1,9 @@
+#ifndef PRIMES_H
+#define PRIMES_H
+
+typedef unsigned int uint32;
+
+int is_prime(uint32 n);
+uint32 next_prime(uint32 n);
+
+#endif

--- a/src/spread.c
+++ b/src/spread.c
@@ -2,13 +2,9 @@
 #include <libgen.h>
 #include <string.h>
 #include "hashmap.h"
+#include "config.h"
 
-#define MAX_LINE  1000
-#define MAX_FIELD  100
-#define KEY_FIELDS   4
-#define N_FIELDS     6
-#define FIELD_SEP  ','
-#define trace(s) puts((s))
+#define FIELD_SEP ','
 
 char *get_tag(char *path)
 {
@@ -83,7 +79,7 @@ void write_line(char **tags, char keys[][MAX_FIELD], int len)
   for (int i=0; i < len; i++) {
     putchar(FIELD_SEP);
     h_pop(tags[i], val);
-    if (strlen(val))
+    if (val > '\0')
       fputs(val, stdout);
   }
   putchar('\n');

--- a/src/spread.c
+++ b/src/spread.c
@@ -3,8 +3,6 @@
 #include <string.h>
 #include "hashmap.h"
 
-#define TRUE         1
-#define FALSE        0
 #define MAX_LINE  1000
 #define MAX_FIELD  100
 #define KEY_FIELDS   4
@@ -12,27 +10,13 @@
 #define FIELD_SEP  ','
 #define trace(s) puts((s))
 
-/* // Using a 2d char array instead
-typedef struct {
-  char chrom[MAX_FIELD];
-  char pos[MAX_FIELD];
-  char strand[MAX_FIELD];
-  char mc_class[MAX_FIELD];
-  char tag[MAX_FIELD];
-  char state[MAX_FIELD];
-} Record;
-*/
-
 char *get_tag(char *path)
 {
   char *t, *u;
   t = basename(path);
   if ((u = strchr(t, '_')) != NULL)
     *u = '\0';
-  char *out = (char *) malloc((strlen(t) + 1) * sizeof(*t));
-  for (int i=0; (out[i] = t[i]) != '\0'; i++)
-    ;
-  return out;
+  return strdup(t);
 }
 
 void write_header(char **tags, int n)
@@ -82,8 +66,8 @@ int compare_keys(char record[][MAX_FIELD], char keys[][MAX_FIELD])
 {
   for (int i=0; i < KEY_FIELDS; i++)
     if (strcmp(record[i], keys[i]) != 0)
-      return FALSE;
-  return TRUE;
+      return 0;
+  return 1;
 }
 
 void write_line(char **tags, char keys[][MAX_FIELD], int len)
@@ -99,7 +83,7 @@ void write_line(char **tags, char keys[][MAX_FIELD], int len)
   for (int i=0; i < len; i++) {
     putchar(FIELD_SEP);
     h_pop(tags[i], val);
-    if (val[0] > '\0')
+    if (strlen(val))
       fputs(val, stdout);
   }
   putchar('\n');

--- a/src/spread.c
+++ b/src/spread.c
@@ -79,7 +79,7 @@ void write_line(char **tags, char keys[][MAX_FIELD], int len)
   for (int i=0; i < len; i++) {
     putchar(FIELD_SEP);
     h_pop(tags[i], val);
-    if (val > '\0')
+    if (val[0] > '\0')
       fputs(val, stdout);
   }
   putchar('\n');

--- a/src/spread.c
+++ b/src/spread.c
@@ -110,6 +110,7 @@ int main(int argc, char *argv[])
   char line[MAX_LINE];
   char **tags = (char **) malloc(--argc * sizeof(char *));
   char record[N_FIELDS][MAX_FIELD], keys[KEY_FIELDS][MAX_FIELD];
+  h_ins(argc);
 
   for (int i=0; i < argc; i++)
     tags[i] = get_tag(argv[i+1]);


### PR DESCRIPTION
Instead of using the proper implementation of the "pop" function for the hashmap, `h_pop()` now just sets the element's value to a null string after copying its value to `dest`.

The reason I am doing this is because we are going to be using the same keys over and over, so it's better just to allocate the memory once than to remove each node after accessing its value. I know this is not a proper "pop" function anymore, but it does not have to be a general case here because we have control over how it is being used within the context of this project.